### PR TITLE
GHC parser error

### DIFF
--- a/src/Data/Multihash/Digest.hs
+++ b/src/Data/Multihash/Digest.hs
@@ -37,8 +37,6 @@ data HashAlgorithm
     | SHA3_384
     | SHA3_256
     | SHA3_224
-    -- | BLAKE2B
-    -- | BLAKE2S
     deriving (Show, Read, Eq, Enum, Bounded)
 
 


### PR DESCRIPTION
Some old GHC versions throw parser error on `src/Data/Multihash/Digest.hs:42`.

This pull request fix it.