### PR TITLE
Remove version constraints on dependencies

### DIFF
--- a/hs-multihash.cabal
+++ b/hs-multihash.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2944cdbebc8e14f5ea687b1b2717e646305e4c56a039f73cb80934dd453f5d2e
+-- hash: a8a837ad27773de5aeab971b4c0eff37c09f3be98b37c3a84f6c014eb6263df7
 
 name:           hs-multihash
 version:        0.2.1
@@ -40,15 +40,15 @@ library
   hs-source-dirs:
       src
   build-depends:
-      attoparsec >=0.12 && <0.14
+      attoparsec
     , base >=4.7 && <5
-    , base58-bytestring >=0.1 && <0.2
-    , base64-bytestring >=1.0 && <1.1
-    , bytestring >=0.10 && <0.11
-    , cryptonite >=0.23 && <0.26
-    , hex >=0.1 && <0.2
-    , io-streams >=1.2 && <1.6
-    , memory >=0.14 && <0.15
+    , base58-bytestring
+    , base64-bytestring
+    , bytestring
+    , cryptonite
+    , hex
+    , io-streams
+    , memory
   default-language: Haskell2010
 
 executable multihash-exe
@@ -60,8 +60,8 @@ executable multihash-exe
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -funbox-strict-fields -fdicts-cheap -O2
   build-depends:
       base >=4.7 && <5
-    , bytestring >=0.10 && <0.11
+    , bytestring
     , hs-multihash
-    , io-streams >=1.2 && <1.6
-    , optparse-applicative >=0.11 && <0.15
+    , io-streams
+    , optparse-applicative
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -24,14 +24,14 @@ library:
     - Data.Multihash.Digest
     - System.IO.Streams.Crypto
   dependencies:
-    - attoparsec >= 0.12 && < 0.14
-    - base58-bytestring >= 0.1  && < 0.2
-    - base64-bytestring >= 1.0  && < 1.1
-    - bytestring >= 0.10 && < 0.11
-    - cryptonite >= 0.23 && < 0.26
-    - hex >= 0.1  && < 0.2
-    - io-streams >= 1.2  && < 1.6
-    - memory >= 0.14 && < 0.15
+    - attoparsec
+    - base58-bytestring
+    - base64-bytestring
+    - bytestring
+    - cryptonite
+    - hex
+    - io-streams
+    - memory
 
 executables:
   multihash-exe:
@@ -39,9 +39,9 @@ executables:
     source-dirs: app
     dependencies:
       - hs-multihash
-      - bytestring >= 0.10 && < 0.11
-      - io-streams >= 1.2 && < 1.6
-      - optparse-applicative >= 0.11 && < 0.15
+      - bytestring
+      - io-streams
+      - optparse-applicative
     ghc-options:
       - -threaded
       - -rtsopts


### PR DESCRIPTION
Remove version constraints in `package.yaml` so that our overlay can supply dependencies from newer nixpkgs rev. 